### PR TITLE
Better Model Inference and intellisense

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cubie-ai/tiny-ai",
-  "version": "0.0.11",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cubie-ai/tiny-ai",
-      "version": "0.0.11",
+      "version": "0.0.14",
       "license": "ISC",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.10",

--- a/src/agent/agent.types.ts
+++ b/src/agent/agent.types.ts
@@ -68,16 +68,20 @@ export type VercelStreamTextParams = Omit<
   "model" | "tools"
 >;
 
-export type GenerateStreamParams = VercelStreamTextParams & {
-  tools?: TinyTool[];
-  /** The model ID to use for generation. */
-  modelId?: string;
-};
+export type GenerateStreamParams<ModelProviderId extends string = string> =
+  VercelStreamTextParams & {
+    tools?: TinyTool[];
+    /** The model ID to use for generation. */
+    modelId?: ModelProviderId;
+  };
 
 /** Parameters for generating text using the agent. */
-export type GenerateTextParams = VercelGenerateTextParams & {
+export interface GenerateTextParams<ModelProviderId extends string = string> {
   tools?: TinyTool[];
 
   /** The model ID to use for generation. */
-  modelId?: string;
-};
+  modelId?: ModelProviderId;
+
+  /** Other parameters for text generation */
+  [key: string]: any;
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,4 +1,5 @@
 export * from "./anthropic";
 export * from "./base";
 export * from "./openai";
+export * from "./types";
 export * from "./xai";

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,0 +1,6 @@
+import { TinyProvider } from "./base";
+
+export type ProviderModelId<Provider extends TinyProvider<any, any, any>> =
+  Provider extends TinyProvider<any, any, infer ModelProviderId>
+    ? ModelProviderId
+    : never;

--- a/tests/agent/agent.test.ts
+++ b/tests/agent/agent.test.ts
@@ -18,6 +18,7 @@ describe("TinyAgent", () => {
     const agent = new TinyAgent({
       provider,
     });
+
     expect(agent).toBeDefined();
     expect(agent.name).toBe("TinyAgent");
     expect(agent.provider).toBeDefined();
@@ -28,6 +29,7 @@ describe("TinyAgent", () => {
       name: "testAgent",
       provider,
     });
+
     expect(agent).toBeDefined();
     expect(agent.name).toBe("testAgent");
   });
@@ -39,6 +41,7 @@ describe("TinyAgent settings", () => {
       name: "testAgent",
       provider: new TinyAnthropic({ apiKey: "test-api-key" }),
     });
+
     expect(agent.settings).toEqual(agent.defaultSettings());
   });
 
@@ -58,6 +61,7 @@ describe("TinyAgent settings", () => {
       provider: new TinyAnthropic({ apiKey: "test-api-key" }),
       settings: {},
     });
+
     expect(agent.settings).toEqual({});
   });
 });


### PR DESCRIPTION
This fix allows for the supported models of a Provider to be inferred when using `.generateText` and `.streamText`.
Example:
<img width="569" alt="image" src="https://github.com/user-attachments/assets/4ba0600c-40d9-41a2-ad6f-6a3e0b10e586" />
